### PR TITLE
Refactored to use hashlib in favor of `django.utils.hashcompat`

### DIFF
--- a/emailconfirmation/models.py
+++ b/emailconfirmation/models.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 from random import random
 
 from django.conf import settings
@@ -6,7 +7,6 @@ from django.db import models, IntegrityError
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.template.loader import render_to_string
-from django.utils.hashcompat import sha_constructor
 from django.utils.translation import gettext_lazy as _
 
 from django.contrib.sites.models import Site
@@ -91,8 +91,8 @@ class EmailConfirmationManager(models.Manager):
             return email_address
     
     def send_confirmation(self, email_address):
-        salt = sha_constructor(str(random())).hexdigest()[:5]
-        confirmation_key = sha_constructor(salt + email_address.email).hexdigest()
+        salt = hashlib.sha1(str(random())).hexdigest()[:5]
+        confirmation_key = hashlib.sha1(salt + email_address.email).hexdigest()
         current_site = Site.objects.get_current()
         # check for the url with the dotted view path
         try:


### PR DESCRIPTION
`hashcompat` was deprecated and loses support in Django 1.6
